### PR TITLE
Changed freeze period from 3 days to 30 days

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -33,7 +33,7 @@
 调用 `expire` 命令，它只有 `proposal_name` 这个参数。
 它可以将提案的 `expires_at` 字段修改为当前时间，而不是等待它原始的到期时间。
 
-提案过期后（无论是手动还是自动过期），进入3天的冻结期。
+提案过期后（无论是手动还是自动过期），进入30天的冻结期。
 在此冻结期内，该提案被锁定，并且不能调用任何操作（包括改投票、删除投票和清理）。
 这时间段是为了让多个工具可以查询结果以进行交叉验证的。
 一旦结束冻结期，可以通过 `clnproposal` 命令清理提案。
@@ -126,12 +126,12 @@ export EOSC_GLOBAL_VAULT_FILE ="`pwd` / tests / eosc-vault.json"
 然后执行 `tests` 文件夹中的所有集成测试（想知道拾取的具体文件，请参见 [all.sh](./tests/all.sh)）。
 
 正确运行测试，你需要要把提案冻结期切换为2秒
-（不然你等3天有点太长了！）
+（不然你等30天有点太长了！）
 
 在文件 [include/forum.hpp](./include/forum.hpp) 中，把下面这行：
 
 ```
-constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 3 * 24 * 60 * 60;
+constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 30 * 24 * 60 * 60;
 ```
 
 改成这样：
@@ -257,7 +257,7 @@ eosc forum vote voter1 example 0
 
 - 当缺少 `voter` 的签名时
 - 当`proposal_name`不存在时
-- 当`proposal_name`过期但在其3天冻结期内时
+- 当`proposal_name`过期但在其30天冻结期内时
 
 ##### 例如
 
@@ -307,7 +307,7 @@ eosc forum expire proposer1 example
 
 这可以有效清除提案及其所有投票所占用的RAM，多次调用操作直到所有选票都被删除。
 
-只有在提案过期，并且过了它的3天冻结期，提案才能被清除。在冻结期间，提案被锁定并且不接受任何操作。
+只有在提案过期，并且过了它的30天冻结期，提案才能被清除。在冻结期间，提案被锁定并且不接受任何操作。
 
 由于只有过期的提案可以被清理，任何人都可以调用此操作，无需授权。
 
@@ -325,7 +325,7 @@ eosc forum expire proposer1 example
 ##### 拒绝情况
 
 - 当`proposal_name`尚未过期时
-- 当`proposal_name`过期但在其3天冻结期内时
+- 当`proposal_name`过期但在其30天冻结期内时
 
 **注意**给予 `max_count` 的值太大会增加此交易失败的概率，
 由于可能导致CPU使用率过高。 找到最佳点以避免这种情况。

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This amends the proposal's `expires_at` field to the current time instead of wai
 its original expiration date to be reached.
 
 Once a proposal is expired (be it manually or automatically if it passed its expiration date), the
-proposal enters a 3 day freeze period. Within this freeze period, the proposal is locked
+proposal enters a 30 days freeze period. Within this freeze period, the proposal is locked
 and no actions can be called on it (no vote changes, no vote removal (`unvote`) and no clean up).
 This is to allow a period where multiple tools can query the results for cross-verification.
 Once a proposal has ended its freeze period, it's now possible to clean it via the `clnproposal` action.
@@ -143,7 +143,7 @@ executes all the integration tests found in `tests` folder (see [all.sh](./tests
 for exact files picked up).
 
 To correctly run the tests, you will need to switch the freeze period of
-a proposal for 2 seconds (waiting 3 days could be a bit too long!). The `tests.sh`
+a proposal for 2 seconds (waiting 30 days could be a bit too long!). The `tests.sh`
 script takes also care of this changing the freeze period automatically for you
 to 2 seconds so it looks like this instead when the tests runs:
 
@@ -246,7 +246,7 @@ Remove your current active vote, effectively reclaiming the stored RAM of the vo
 your vote will not count anymore (neither positively or negatively) on the current proposal's voting
 statistics.
 
-It's **not** possible to `unvote` on a proposal that is expired but within its freeze period of 3 days.
+It's **not** possible to `unvote` on a proposal that is expired but within its freeze period of 30 days.
 If the proposal is expired and the freeze period has elapsed, it's possible to `unvote` on the proposal.
 To be nice to the community however, you should call [clnproposal](#action-clnproposal) until the proposal
 is fully cleaned up so that every vote will be removed and RAM will be freed for all voters.
@@ -261,7 +261,7 @@ is fully cleaned up so that every vote will be removed and RAM will be freed for
 
 - When missing signature of `voter`
 - When `proposal_name` does not exist
-- When `proposal_name` is expired but within its freeze period of 3 days
+- When `proposal_name` is expired but within its freeze period of 30 days
 
 ##### Example
 
@@ -309,7 +309,7 @@ are no more votes, the proposal itself is deleted.
 This effectively clears all the RAM consumed for a proposal and all its votes. Call the action multiple
 times until all votes are removed.
 
-It's possible to clean a proposal only if it has expired and if its freeze period of 3 days has fully
+It's possible to clean a proposal only if it has expired and if its freeze period of 30 days has fully
 elapsed. Within the freeze period, the proposal is locked and no actions can be performed on it.
 Since only expired proposals can be cleaned, anybody can invoke this action, no authorization is required.
 Voters, proposers, or any community member is invited to call `clnproposal` to clean the RAM related to
@@ -327,7 +327,7 @@ terminated its lifecycle.
 ##### Rejections
 
 - When `proposal_name` is not expired yet
-- When `proposal_name` is expired but within its freeze period of 3 days
+- When `proposal_name` is expired but within its freeze period of 30 days
 
 **Note** Giving a `max_count` that is too big increases the probability that the transaction
 fails due to excessive CPU usage. Find the sweet spot to avoid that.

--- a/include/forum.hpp
+++ b/include/forum.hpp
@@ -63,8 +63,8 @@ class [[eosio::contract("forum")]] forum : public eosio::contract {
         void status(const name account, const string& content);
 
     private:
-        // 3 days in seconds (Computation: 3 days * 24 hours * 60 minutes * 60 seconds)
-        constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 3 * 24 * 60 * 60;
+        // 30 days in seconds (Computation: 30 days * 24 hours * 60 minutes * 60 seconds)
+        constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 30 * 24 * 60 * 60;
 
         // 6 months in seconds (Computatio: 6 months * average days per month * 24 hours * 60 minutes * 60 seconds)
         constexpr static uint32_t SIX_MONTHS_IN_SECONDS = (uint32_t) (6 * (365.25 / 12) * 24 * 60 * 60);

--- a/src/forum.cpp
+++ b/src/forum.cpp
@@ -108,7 +108,7 @@ void forum::unvote(const name voter, const name proposal_name) {
  *
  * This method allows anyone to clean a proposal if the proposal is either expired or does
  * not exist anymore. This exact case can only happen either by itself (the proposal has reached
- * its expiration time) or by the a proposer action (`expire`). In either case, 3 days must elapse before calling `clnproposal`.
+ * its expiration time) or by the a proposer action (`expire`). In either case, 30 days must elapse before calling `clnproposal`.
  *
  * In all cases it's ok to let anyone clean the votes since there is no more "use"
  * for the proposal nor the votes.
@@ -119,7 +119,7 @@ void forum::clnproposal(const name proposal_name, uint64_t max_count) {
 
     auto itr = proposal_table.find(proposal_name.value);
     eosio_assert(itr == proposal_table.end() || itr->can_be_cleaned_up(),
-                 "proposal must not exist or be expired for at least 3 days prior to running clnproposal.");
+                 "proposal must not exist or be expired for at least 30 days prior to running clnproposal.");
 
     votes vote_table(_self, _self.value);
     auto index = vote_table.template get_index<"byproposal"_n>();

--- a/tests.sh
+++ b/tests.sh
@@ -3,7 +3,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd tests && pwd )"
 
 freeze_period_constant_2s='constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 2; // NEVER MERGE LIKE THIS'
-freeze_period_constant_30d='constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 3 \* 24 \* 60 \* 60;'
+freeze_period_constant_30d='constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 30 \* 24 \* 60 \* 60;'
 
 include_file="$ROOT/../include/forum.hpp"
 include_backup_file="$ROOT/../include/forum.hpp.bak"

--- a/tests/clnproposal_validates_correctly.sh
+++ b/tests/clnproposal_validates_correctly.sh
@@ -9,7 +9,7 @@ action_ok propose proposer1@active \
 
 action_ko clnproposal proposer1@active \
 '{"proposal_name":"clrfiprone4", "max_count": 1}' \
-'proposal must not exist or be expired for at least 3 days prior to running clnproposal.'
+'proposal must not exist or be expired for at least 30 days prior to running clnproposal.'
 
 println
 
@@ -23,4 +23,4 @@ action_ok expire proposer1@active \
 
 action_ko clnproposal proposer1@active \
 '{"proposal_name":"clrfiprogp4", "max_count": 1}' \
-'proposal must not exist or be expired for at least 3 days prior to running clnproposal.'
+'proposal must not exist or be expired for at least 30 days prior to running clnproposal.'

--- a/tests/clnproposal_working.sh
+++ b/tests/clnproposal_working.sh
@@ -5,7 +5,7 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"; source "${ROOT}/librar
 ###
 # **Important**
 #
-# Usually, the freeze period before cleaning proposal is 3 days. The tests
+# Usually, the freeze period before cleaning proposal is 30 days. The tests
 # in this file expect that the freeze period is set to 2s only!
 #
 # You will need to modify the source code of the contract before running

--- a/tests/propose_validates_correctly.sh
+++ b/tests/propose_validates_correctly.sh
@@ -2,7 +2,7 @@
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"; source "${ROOT}/library.sh"
 
-expires_at_expired=`date -v-1S +"%Y-%m-%dT%H:%M:%S"`
+expires_at_already_expired=`date -v-1S +"%Y-%m-%dT%H:%M:%S"`
 expires_at_over=`date -v+7m +"%Y-%m-%dT%H:%M:%S"`
 proposal_json_not_object="[]"
 proposal_json_too_long="{\\\\"a\\\\":\\\\"${CHARS_37500}\\\\"}"
@@ -16,7 +16,7 @@ action_ko propose proposer1@active \
 'title should be less than 1024 characters long.'
 
 action_ko propose proposer1@active \
-"{\"proposer\":\"proposer1\", \"proposal_name\":\"provalcorr1\", \"title\":\"A simple one\", \"proposal_json\":null, \"expires_at\":\"${expires_at_expired}\"}" \
+"{\"proposer\":\"proposer1\", \"proposal_name\":\"provalcorr1\", \"title\":\"A simple one\", \"proposal_json\":null, \"expires_at\":\"${expires_at_already_expired}\"}" \
 'expires_at must be a value in the future.'
 
 action_ko propose proposer1@active \

--- a/tests/unvote_working.sh
+++ b/tests/unvote_working.sh
@@ -5,7 +5,7 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"; source "${ROOT}/librar
 ###
 # **Important**
 #
-# Usually, the freeze period before cleaning proposal is 3 days. The tests
+# Usually, the freeze period before cleaning proposal is 30 days. The tests
 # in this file expect that the freeze period is set to 2s only!
 #
 # You will need to modify the source code of the contract before running

--- a/tests/vote_validates_correctly.sh
+++ b/tests/vote_validates_correctly.sh
@@ -5,7 +5,7 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"; source "${ROOT}/librar
 ###
 # **Important**
 #
-# Usually, the freeze period before cleaning proposal is 3 days. The tests
+# Usually, the freeze period before cleaning proposal is 30 days. The tests
 # in this file expect that the freeze period is set to 2s only!
 #
 # You will need to modify the source code of the contract before running


### PR DESCRIPTION
Following discussion in Referendum Core Team, this PR bumps the freeze period from 3 days to 30 days.

Some discussion from there copied as future reference:

> I was just going to ask for a longer time delay between expiry and expungement, like 30 days. If a proposal is controversial and the tally is close, we need time for folks to run their own tallies

> In short, to make sure there is enough time for anyone to tally the votes in a way they see fit and cross verify. AND to make sure that a vote doesnt finish and then a few days later someone makes a vote with the same proposal name right away after to cause confusion